### PR TITLE
Unicorn defaults: Preload app and AR connections

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -9,9 +9,10 @@ default["rackbox"]["default_config"]["nginx"]["listen_port"] = "80"
 
 default["rackbox"]["default_config"]["unicorn"]["listen_port_options"] = { :tcp_nodelay => true, :backlog => 100 }
 default["rackbox"]["default_config"]["unicorn"]["worker_timeout"] = 60
-default["rackbox"]["default_config"]["unicorn"]["preload_app"] = false
+default["rackbox"]["default_config"]["unicorn"]["preload_app"] = true
 default["rackbox"]["default_config"]["unicorn"]["worker_processes"] = [node[:cpu][:total].to_i * 4, 8].min
-default["rackbox"]["default_config"]["unicorn"]["before_fork"] = 'sleep 1'
+default["rackbox"]["default_config"]["unicorn"]["before_fork"] = 'defined?(ActiveRecord::Base) and ActiveRecord::Base.connection.disconnect!'
+default["rackbox"]["default_config"]["unicorn"]["after_fork"] = 'defined?(ActiveRecord::Base) and ActiveRecord::Base.establish_connection'
 
 default["rackbox"]["default_config"]["unicorn_runit"]["template_name"] = "unicorn"
 default["rackbox"]["default_config"]["unicorn_runit"]["template_cookbook"] = "rackbox"


### PR DESCRIPTION
- Preload unicorn apps by default.
- Unicorn before_fork disconnects ActiveRecord connections
- Unicorn after_fork establishes ActiveRecord connections
- See https://devcenter.heroku.com/articles/rails-unicorn#preload-app
