### PR TITLE
Un-comment rack detection

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -46,7 +46,7 @@ module Rackbox
           :user                 => node["appbox"]["apps_user"],
           :group                => node["appbox"]["apps_user"],
           :rack_env            => config["rack_env"],
-          :smells_like_rack     => true, #::File.exists?(::File.join(app_dir, "config.ru")),
+          :smells_like_rack     => ::File.exists?(::File.join(app_dir, "config.ru")),
           :unicorn_config_file  => unicorn_config_file,
           :working_directory    => app_dir
         )


### PR DESCRIPTION
This cookbook works great for my Rails 2 app with this one line uncommented. Looks like it got accidentally commented in 70e581044ae5ba36a64371661329e32dd99ce98e
