### PR TITLE
Listen on 443 if SSL is enabled

### DIFF
--- a/templates/default/nginx_vhost.conf.erb
+++ b/templates/default/nginx_vhost.conf.erb
@@ -11,7 +11,7 @@ server {
   root <%= @root_path %>;
 
 <% if @ssl_key && @ssl_cert -%>
-  ssl on;
+  listen 443 ssl;
   ssl_certificate     <%= @ssl_cert %>;
   ssl_certificate_key <%= @ssl_key %>;
   ssl_protocols SSLv3 TLSv1;


### PR DESCRIPTION
If SSL is on, we should be listening on 443. I suppose you could define two sites, but I think listening on both 80 (or another port not intended for SSL) and 443 is the most common use-case. Even if you only want HTTPS traffic, you'll listen on 80 to redirect to https.

I deployed with this change and it's working great. If you have another way to approach the problem, though, I'd be interested to know!

Thanks!

ref: http://serverfault.com/a/10937/145923
