### PR TITLE
Avoid empty unicorn/passenger apps list install dependencies

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -8,10 +8,10 @@ include_recipe "rackbox::ruby"
 include_recipe "rackbox::nginx"
 include_recipe "runit"
 
-if node["rackbox"]["apps"]["unicorn"]
+if node["rackbox"]["apps"]["unicorn"].any?
   include_recipe "rackbox::unicorn"
 end
 
-if node["rackbox"]["apps"]["passenger"]
+if node["rackbox"]["apps"]["passenger"].any?
   include_recipe "rackbox::passenger"
 end


### PR DESCRIPTION
Both unicorn/passenger node elements are expected to be an array.

Instead of checking if the element is defined -- which is by default --
we check if the element has any value in it.

Thank you :heart: :heart: :heart: 
